### PR TITLE
Clean-up

### DIFF
--- a/ban.py
+++ b/ban.py
@@ -140,7 +140,7 @@ class ban(minqlx.Plugin):
         try:
             ident = int(msg[1])
             target_player = None
-            if ident >= 0 and ident < 64:
+            if 0 <= ident < 64:
                 target_player = self.player(ident)
                 ident = target_player.steam_id
         except ValueError:
@@ -210,7 +210,7 @@ class ban(minqlx.Plugin):
         try:
             ident = int(msg[1])
             target_player = None
-            if ident >= 0 and ident < 64:
+            if 0 <= ident < 64:
                 target_player = self.player(ident)
                 ident = target_player.steam_id
         except ValueError:
@@ -244,7 +244,7 @@ class ban(minqlx.Plugin):
         try:
             ident = int(msg[1])
             target_player = None
-            if ident >= 0 and ident < 64:
+            if 0 <= ident < 64:
                 target_player = self.player(ident)
                 ident = target_player.steam_id
         except ValueError:
@@ -284,7 +284,7 @@ class ban(minqlx.Plugin):
         try:
             ident = int(msg[1])
             target_player = None
-            if ident >= 0 and ident < 64:
+            if 0 <= ident < 64:
                 target_player = self.player(ident)
                 ident = target_player.steam_id
         except ValueError:
@@ -354,7 +354,7 @@ class ban(minqlx.Plugin):
 
         completed = self.db[PLAYER_KEY.format(steam_id) + ":games_completed"]
         left = self.db[PLAYER_KEY.format(steam_id) + ":games_left"]
-        if completed == None or left == None:
+        if completed is None or left is None:
             return None
         else:
             completed = int(completed)
@@ -382,7 +382,7 @@ class ban(minqlx.Plugin):
         else:
             action = None
 
-        return (action, ratio)
+        return action, ratio
 
     def warn_player(self, player, ratio):
         player.tell("^7You have only completed ^6{}^7 percent of your games.".format(round(ratio * 100, 1)))

--- a/clan.py
+++ b/clan.py
@@ -32,7 +32,7 @@ class clan(minqlx.Plugin):
         # without having to worry about duplicate entries.
         if not value: # Player disconnected?
             return
-        elif index >= 529 and index < 529 + 64:
+        elif 529 <= index < 529 + 64:
             player = self.player(index - 529)
             if not player:
                 # This happens when someone connects, but the player

--- a/essentials.py
+++ b/essentials.py
@@ -213,7 +213,7 @@ class essentials(minqlx.Plugin):
         try:
             i = int(msg[1])
             target_player = self.player(i)
-            if not (i >= 0 and i < 64) or not target_player:
+            if not (0 <= i < 64) or not target_player:
                 raise ValueError
         except ValueError:
             player.tell("Invalid ID.")
@@ -239,7 +239,7 @@ class essentials(minqlx.Plugin):
         try:
             i = int(msg[1])
             target_player = self.player(i)
-            if not (i >= 0 and i < 64) or not target_player:
+            if not (0 <= i < 64) or not target_player:
                 raise ValueError
         except ValueError:
             player.tell("Invalid ID.")
@@ -282,7 +282,7 @@ class essentials(minqlx.Plugin):
         try:
             i = int(msg[1])
             target_player = self.player(i)
-            if not (i >= 0 and i < 64) or not target_player:
+            if not (0 <= i < 64) or not target_player:
                 raise ValueError
         except ValueError:
             channel.reply("Invalid ID.")
@@ -301,13 +301,13 @@ class essentials(minqlx.Plugin):
         try:
             i = int(msg[1])
             target_player = self.player(i)
-            if not (i >= 0 and i < 64) or not target_player:
+            if not (0 <= i < 64) or not target_player:
                 raise ValueError
         except ValueError:
             channel.reply("Invalid ID.")
             return
 
-            target_player.tempban()
+        target_player.tempban()
 
     def cmd_yes(self, player, msg, channel):
         """Passes the current vote."""
@@ -331,7 +331,7 @@ class essentials(minqlx.Plugin):
         try:
             i1 = int(msg[1])
             player1 = self.player(i1)
-            if not (i1 >= 0 and i1 < 64) or not player1:
+            if not (0 <= i1 < 64) or not player1:
                 raise ValueError
         except ValueError:
             channel.reply("The first ID is invalid.")
@@ -340,7 +340,7 @@ class essentials(minqlx.Plugin):
         try:
             i2 = int(msg[2])
             player2 = self.player(i2)
-            if not (i2 >= 0 and i2 < 64) or not player2:
+            if not (0 <= i2 < 64) or not player2:
                 raise ValueError
         except ValueError:
             channel.reply("The second ID is invalid.")
@@ -356,7 +356,7 @@ class essentials(minqlx.Plugin):
         try:
             i = int(msg[1])
             target_player = self.player(i)
-            if not (i >= 0 and i < 64) or not target_player:
+            if not (0 <= i < 64) or not target_player:
                 raise ValueError
         except ValueError:
             channel.reply("Invalid ID.")
@@ -372,7 +372,7 @@ class essentials(minqlx.Plugin):
         try:
             i = int(msg[1])
             target_player = self.player(i)
-            if not (i >= 0 and i < 64) or not target_player:
+            if not (0 <= i < 64) or not target_player:
                 raise ValueError
         except ValueError:
             channel.reply("Invalid ID.")
@@ -389,7 +389,7 @@ class essentials(minqlx.Plugin):
         try:
             i = int(msg[1])
             target_player = self.player(i)
-            if not (i >= 0 and i < 64) or not target_player:
+            if not (0 <= i < 64) or not target_player:
                 raise ValueError
         except ValueError:
             channel.reply("Invalid ID.")
@@ -405,7 +405,7 @@ class essentials(minqlx.Plugin):
         try:
             i = int(msg[1])
             target_player = self.player(i)
-            if not (i >= 0 and i < 64) or not target_player:
+            if not (0 <= i < 64) or not target_player:
                 raise ValueError
         except ValueError:
             channel.reply("Invalid ID.")
@@ -421,7 +421,7 @@ class essentials(minqlx.Plugin):
         try:
             i = int(msg[1])
             target_player = self.player(i)
-            if not (i >= 0 and i < 64) or not target_player:
+            if not (0 <= i < 64) or not target_player:
                 raise ValueError
         except ValueError:
             channel.reply("Invalid ID.")
@@ -437,7 +437,7 @@ class essentials(minqlx.Plugin):
         try:
             i = int(msg[1])
             target_player = self.player(i)
-            if not (i >= 0 and i < 64) or not target_player:
+            if not (0 <= i < 64) or not target_player:
                 raise ValueError
         except ValueError:
             channel.reply("Invalid ID.")
@@ -453,7 +453,7 @@ class essentials(minqlx.Plugin):
         try:
             i = int(msg[1])
             target_player = self.player(i)
-            if not (i >= 0 and i < 64) or not target_player:
+            if not (0 <= i < 64) or not target_player:
                 raise ValueError
         except ValueError:
             channel.reply("Invalid ID.")
@@ -469,7 +469,7 @@ class essentials(minqlx.Plugin):
         try:
             i = int(msg[1])
             target_player = self.player(i)
-            if not (i >= 0 and i < 64) or not target_player:
+            if not (0 <= i < 64) or not target_player:
                 raise ValueError
         except ValueError:
             channel.reply("Invalid ID.")
@@ -488,7 +488,7 @@ class essentials(minqlx.Plugin):
         try:
             i = int(msg[1])
             target_player = self.player(i)
-            if not (i >= 0 and i < 64) or not target_player:
+            if not (0 <= i < 64) or not target_player:
                 raise ValueError
         except ValueError:
             channel.reply("Invalid ID.")

--- a/permission.py
+++ b/permission.py
@@ -40,7 +40,7 @@ class permission(minqlx.Plugin):
         try:
             ident = int(msg[1])
             target_player = None
-            if ident >= 0 and ident < 64:
+            if 0 <= ident < 64:
                 target_player = self.player(ident)
                 ident = target_player.steam_id
         except ValueError:
@@ -69,7 +69,7 @@ class permission(minqlx.Plugin):
         try:
             ident = int(msg[1])
             target_player = None
-            if ident >= 0 and ident < 64:
+            if 0 <= ident < 64:
                 target_player = self.player(ident)
                 ident = target_player.steam_id
 
@@ -81,7 +81,7 @@ class permission(minqlx.Plugin):
             return
         
         perm = self.db.get_permission(ident)
-        if perm == None:
+        if perm is None:
             channel.reply("I do not know ^6{}^7.".format(msg[1]))
         else:
             if target_player:
@@ -95,7 +95,7 @@ class permission(minqlx.Plugin):
             return
         
         perm = self.db.get_permission(player)
-        if perm == None:
+        if perm is None:
             channel.reply("I do not know you.")
         else:
             channel.reply("You have permission level ^6{}^7.".format(perm))


### PR DESCRIPTION
- Simplified chained comparisons
- Replaced == with is on None comparisons. From PEP 8, "comparisons to singletons like None should always be done with is or is not, never the equality operators."
- Line 310 of essentials.py was unreachable.
