### PR TITLE
add cointoss and random number capabilities

### DIFF
--- a/essentials.py
+++ b/essentials.py
@@ -25,6 +25,7 @@ import itertools
 import time
 import re
 import os
+from random import randint
 
 from collections import deque
 
@@ -58,6 +59,8 @@ class essentials(minqlx.Plugin):
         self.add_command(("kickban", "tempban"), self.cmd_kickban, 2, usage="<id>")
         self.add_command("yes", self.cmd_yes, 2)
         self.add_command("no", self.cmd_no, 2)
+        self.add_command("random", self.cmd_random, 1, usage="<number highwater>")
+        self.add_command("cointoss", self.cmd_cointoss, 1)
         self.add_command("switch", self.cmd_switch, 1, usage="<id> <id>")
         self.add_command("red", self.cmd_red, 1, usage="<id>")
         self.add_command("blue", self.cmd_blue, 1, usage="<id>")
@@ -419,6 +422,29 @@ class essentials(minqlx.Plugin):
         else:
             channel.reply("There is no active vote!")
 
+    def cmd_random(self, player, msg, channel):
+        """Presents a random number in chat."""
+        if len(msg) < 2:
+            return minqlx.RET_USAGE
+        
+        try:
+            randomNumber = randint(1,int(msg[1]))
+        except:
+            return minqlx.RET_USAGE
+        
+        channel.reply("^3Random number is: ^5{}".format(randomNumber))
+        
+    def cmd_cointoss(self, player, msg, channel):
+        """Tosses a coin, and returns HEADS or TAILS in chat."""
+        randomNumber = randint(0,1)
+        
+        if randomNumber == 0:
+            coin = "HEADS"
+        elif randomNumber == 1:
+            coin = "TAILS"
+        
+        channel.reply("^3The coin is: ^5{}".format(coin))
+        
     def cmd_switch(self, player, msg, channel):
         """Switches the teams of the two players."""
         if len(msg) < 3:


### PR DESCRIPTION
In minqlbot, !cointoss would call and pass a cointoss vote.

In the latest iteration of Quake Live, there remains the cointoss vote, and a new random number vote. This file change re-adds this functionality to minqlx, and completely bypasses the need for a vote.
