### PR TITLE
fix spectator name pre-colouring

### DIFF
--- a/names.py
+++ b/names.py
@@ -93,6 +93,7 @@ class names(minqlx.Plugin):
             return minqlx.RET_STOP_ALL
 
         self.name_set = True
+        name = "^7" + name
         player.name = name
         self.db[name_key] = name
         player.tell("The name has been registered. To make me forget about it, a simple ^6{}name^7 will do it."


### PR DESCRIPTION
this change stops the pre-shading of the player name in-game (on spec hud), of either a red or blue shade, depending on their team. Reason for this is it conflicts with what the player imagines their name appears as throughout the game.

Screenshots of issue:
http://imgur.com/a/seVyf
