### PR TITLE
Saving the clan tag before set_configstring executing

### DIFF
--- a/clan.py
+++ b/clan.py
@@ -72,8 +72,8 @@ class clan(minqlx.Plugin):
         cs["xcn"] = tag
         cs["cn"] = tag
         new_cs = "".join(["\\{}\\{}".format(key, cs[key]) for key in cs])
-        minqlx.set_configstring(index, new_cs)
         self.db[tag_key] = tag
+        minqlx.set_configstring(index, new_cs)
         self.msg("{} changed clan tag to {}".format(player, tag))
         return minqlx.RET_STOP_EVENT
 


### PR DESCRIPTION
I did that for my plugin queue.py to work proper, when the players using !clan. If you have the time, maybe you can take a look how i [handling the set_configstring](https://github.com/Melodeiro/minqlx-plugins_mattiZed/blob/master/queue.py#L279), and maybe there is better solution. Just using player.clan like mattiZed did creates infinite loop when the player is in spectators because calling palyer.clan starts the new set_configstring for him.
