### PR TITLE
Syntax update on irc.py

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -294,24 +294,22 @@ class SimpleAsyncIrc(threading.Thread):
             with self._lock:
                 self.writer.write(msg.encode(errors="ignore"))
 
-    @asyncio.coroutine
-    def connect(self):
-        self.reader, self.writer = yield from asyncio.open_connection(self.host, self.port)
+    async def connect(self):
+        self.reader, self.writer = await asyncio.open_connection(self.host, self.port)
         self.write("NICK {0}\r\nUSER {0} 0 * :{0}\r\n".format(self.nickname))
         
         while not self.stop_event.is_set():
-            line = yield from self.reader.readline()
+            line = await self.reader.readline()
             if not line:
                 break
             line = line.decode("utf-8", errors="ignore").rstrip()
             if line:
-                yield from self.parse_data(line)
+                await self.parse_data(line)
 
         self.write("QUIT Quit by user.\r\n")
         self.writer.close()
 
-    @asyncio.coroutine
-    def parse_data(self, msg):
+    async def parse_data(self, msg):
         split_msg = msg.split()
         if len(split_msg) > 1 and split_msg[0] == "PING":
             self.pong(split_msg[1].lstrip(":"))


### PR DESCRIPTION
Updated to a async/await syntax for methods connect() and parse_data() instead of @asyncio.coroutine since it's no longer working with python 3.x

As asked on qldev server on discord this update has been running without issues for more than a week on my server